### PR TITLE
let user decide if 'run all' behaviour should be enabled

### DIFF
--- a/lib/guard/rubocop.rb
+++ b/lib/guard/rubocop.rb
@@ -18,7 +18,8 @@ module Guard
         all_on_start: true,
         keep_failed:  true,
         notification: :failed,
-        cli: nil
+        cli: nil,
+        run_all: true
       }.merge(options)
 
       @failed_paths = []
@@ -29,8 +30,12 @@ module Guard
     end
 
     def run_all
-      UI.info 'Inspecting Ruby code style of all files'
-      inspect_with_rubocop
+      if @options[:run_all]
+        UI.info 'Inspecting Ruby code style of all files'
+        inspect_with_rubocop
+      else
+        UI.info 'Guard is not allowed to inspect Ruby code style of all files'
+      end
     end
 
     def run_on_additions(paths)

--- a/spec/guard/rubocop_spec.rb
+++ b/spec/guard/rubocop_spec.rb
@@ -31,6 +31,11 @@ describe Guard::Rubocop, :silence_output do
         subject { super()[:cli] }
         it { should be_nil }
       end
+
+      describe '[:run_all]' do
+        subject { super()[:run_all] }
+        it { should be_truthy }
+      end
     end
   end
 
@@ -108,6 +113,15 @@ describe Guard::Rubocop, :silence_output do
     it 'inspects all files with rubocop' do
       expect_any_instance_of(Guard::Rubocop::Runner).to receive(:run).with([])
       guard.run_all
+    end
+
+    context 'when run_all is disabled' do
+      let(:options) { { run_all: false } }
+
+      it 'does not inspect all files with rubocop' do
+        expect_any_instance_of(Guard::Rubocop::Runner).to_not receive(:run)
+        guard.run_all
+      end
     end
   end
 


### PR DESCRIPTION
I'm adding guard-rubocop to a large project that has a lot of rubocop failures. Running rubocop from the terminal grinds for a long time, so I want to control guard-rubocop so it only ever runs on changed files and never runs on the entire project.
