### PR TITLE
Drop support Ruby 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_from: .rubocop_todo.yml
 
+AllCops:
+  TargetRubyVersion: 2.5
+
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Development
 
+* Drop support Ruby 2.4. [#50](https://github.com/rubocop/guard-rubocop/pull/50)
+
 ## v1.4.0
 
 * Support RuboCop 1.0

--- a/guard-rubocop.gemspec
+++ b/guard-rubocop.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/rubocop-hq/guard-rubocop'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }

--- a/lib/guard/rubocop/runner.rb
+++ b/lib/guard/rubocop/runner.rb
@@ -80,11 +80,9 @@ module Guard
       end
 
       def result
-        @result ||= begin
-          File.open(json_file_path) do |file|
-            # Rubinius 2.0.0.rc1 does not support `JSON.load` with 3 args.
-            JSON.parse(file.read, symbolize_names: true)
-          end
+        @result ||= File.open(json_file_path) do |file|
+          # Rubinius 2.0.0.rc1 does not support `JSON.load` with 3 args.
+          JSON.parse(file.read, symbolize_names: true)
         end
       end
 


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/9648.