### PR TITLE
feat: allow array as cmd option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ all_on_start: true     # Check all files at Guard startup.
 cli: '--rails'         # Pass arbitrary RuboCop CLI arguments.
                        # An array or string is acceptable.
                        #   default: nil
-cmd: './bin/rubocop'   # Pass custom cmd to run rubocop.
+cmd: './bin/rubocop'   # Pass custom cmd to run rubocop as String or Array.
                        #   default: rubocop
 
 hide_stdout: false     # Do not display console output (in case outputting to file).
@@ -84,6 +84,17 @@ Configure your Guardfile with the launchy option:
 
 ``` ruby
 guard :rubocop, cli: %w(--format fuubar --format html -o ./tmp/rubocop_results.html), launchy: './tmp/rubocop_results.html' do
+  # ...
+end
+```
+
+### Running with Bundler
+
+guard-rubocop can be configured to run with bundler.
+Configure your Guardfile with the cmd option:
+
+``` ruby
+guard :rubocop, cmd: %w(bundle exec guard) do
   # ...
 end
 ```

--- a/lib/guard/rubocop/runner.rb
+++ b/lib/guard/rubocop/runner.rb
@@ -38,6 +38,7 @@ module Guard
         command << '--force-exclusion'
         command.concat(args_specified_by_user)
         command.concat(paths)
+        command.flatten
       end
 
       def should_add_default_formatter_for_console?

--- a/spec/guard/rubocop/runner_spec.rb
+++ b/spec/guard/rubocop/runner_spec.rb
@@ -118,6 +118,16 @@ RSpec.describe Guard::RuboCop::Runner do
         end
       end
 
+      context 'when set as array' do
+        let(:options) { { cmd: %w[bundle exec rubocop] } }
+
+        it 'uses the supplied :cmd' do
+          expect(build_command[0]).to eq('bundle')
+          expect(build_command[1]).to eq('exec')
+          expect(build_command[2]).to eq('rubocop')
+        end
+      end
+
       context 'when not set' do
         it 'uses the default command' do
           expect(build_command[0]).to eq('rubocop')


### PR DESCRIPTION
This adds the option to pass an array as `cmd` parameter in order to run `rubocop` with `bundler`.

See adapted `README.md` for description and example.